### PR TITLE
Append data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/chrishalbert/slim-apm
 
 go 1.21.5
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,25 +1,49 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 )
 
-func main() {
-	fmt.Println("Hello world")
+type Healthchecks struct {
+	Version string `json:"version"`
+	SlimMetric
 }
 
-func getFileBytes(fileName string) []byte {
+func main() {
+
+	fileBytes, err := getFileBytes("./events.json")
+	if err != nil {
+		fmt.Printf("FAILED TO OPEN LOG FILE: %v", err)
+		return
+	}
+
+	var healthchecks []Healthchecks
+	if err = json.Unmarshal(*fileBytes, &healthchecks); err != nil {
+		fmt.Printf("FAILED TO PARSE JSON: %v", err)
+	}
+
+	oms := NewSlimApp()
+	for _, healthcheck := range healthchecks {
+		oms.AddVersionMetric(healthcheck.Version, healthcheck.SlimMetric)
+	}
+
+}
+
+func getFileBytes(fileName string) (*[]byte, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
 		fmt.Println("error opening file", err)
+		return nil, err
 	}
 
 	fileBytes, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Println("error reading file", err)
+		return nil, err
 	}
 
-	return fileBytes
+	return &fileBytes, nil
 }

--- a/slimapm.go
+++ b/slimapm.go
@@ -1,0 +1,61 @@
+package main
+
+type SlimMetric struct {
+	Timestamp uint32 `json:"timestamp"`
+	QueryTime uint16 `json:"query_time"`
+}
+
+// SlimVersion stores the hash of the version along with aggregates (deliverable 1.)
+type SlimVersion struct {
+	hash            string
+	max             uint16
+	min             uint16
+	avg             float32
+	timestamps      []uint32
+	queryTime       []uint16
+	shouldAggregate bool
+}
+
+// includeMetrics is used to append each Metric
+func (version *SlimVersion) IncludeMetrics(metrics SlimMetric) {
+	version.timestamps = append(version.timestamps, metrics.Timestamp)
+	version.queryTime = append(version.queryTime, metrics.QueryTime)
+}
+
+// Allows for outputing the details (deliverable 4.)
+// func (version *SlimVersion) String() string
+
+// aggregate is called within any accessor to compute aggregate values
+// func (version *SlimVersion) aggregate()
+
+// SlimApp contains a slice of SlimVersions, along w/ the best and worst (deliverable 2.)
+type SlimApp struct {
+	versions        map[string]*SlimVersion
+	best            *SlimVersion
+	worst           *SlimVersion
+	shouldAggregate bool
+}
+
+// NewSlimApp loads the healthcheck metrics into a SlimApp and returns a ptr to the object
+func NewSlimApp() *SlimApp {
+	return &SlimApp{versions: make(map[string]*SlimVersion)}
+}
+
+// AddRaw will construct the SlimVersions slice and check for the best and worst
+func (app *SlimApp) AddVersionMetric(version string, metric SlimMetric) error {
+	if _, ok := app.versions[version]; !ok {
+		app.versions[version] = &SlimVersion{hash: version}
+	}
+	app.versions[version].IncludeMetrics(metric)
+	app.shouldAggregate = true
+	return nil
+}
+
+// GetVersions returns a slice of SlimVersions (deliverable 1.)
+// func (app *SlimApp) GetVersions() []SlimVersion
+
+// GetReleaseHistory returns a Pointer to a map of Times pointing to SlimVersions (deliverable 3.)
+// func (app *SlimApp) GetReleaseHistory() map[uint32]SlimVersion
+
+// aggregate is called within the accessors to rebuild if needed
+// func (app *SlimApp) aggregate()

--- a/slimapm_test.go
+++ b/slimapm_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSlimApp(t *testing.T) {
+	t.Run("should initialize Slim App", func(t *testing.T) {
+		app := NewSlimApp()
+		assert.NotNil(t, app.versions)
+		assert.Nil(t, app.best)
+		assert.Nil(t, app.worst)
+		assert.False(t, app.shouldAggregate)
+	})
+}
+
+func TestAddVersionMetric(t *testing.T) {
+	app := NewSlimApp()
+	version := "abc"
+	metric := SlimMetric{Timestamp: 1, QueryTime: 123}
+	t.Run("should create a new SlimVersion if adding a metric for a new version", func(t *testing.T) {
+		_, ok := app.versions[version]
+		assert.False(t, ok)
+
+		app.AddVersionMetric(version, metric)
+		assert.Nil(t, app.best)
+		assert.Nil(t, app.worst)
+		_, ok = app.versions[version]
+		assert.True(t, ok)
+		assert.True(t, app.shouldAggregate)
+	})
+
+	t.Run("should use existing SlimVersion if adding a metric for an existing version", func(t *testing.T) {
+		appVersionExisting, ok := app.versions[version]
+		assert.True(t, ok)
+
+		app.AddVersionMetric(version, metric)
+		assert.Nil(t, app.best)
+		assert.Nil(t, app.worst)
+
+		appVersion, ok := app.versions[version]
+		assert.True(t, ok)
+		assert.True(t, app.shouldAggregate)
+
+		assert.Equal(t, appVersionExisting, appVersion)
+
+		assert.Equal(t, 2, len(app.versions[version].timestamps))
+		assert.Equal(t, 2, len(app.versions[version].queryTime))
+	})
+}


### PR DESCRIPTION
This PR implements the ETL process of pulling healthcheck metrics from a raw gauge of data. The example file in the original commit (`events.json`) is extracted and appended to the `SlimApp` via the exported `AddVersionMetric` method. This method groups the metrics by version, internally saved by `SlimVersion`s, which saves the data points (`Timestamp` and `QueryTime`) into slices for later analysis. Whenever a `SlimVersion` is appended to, the `shouldAggregate` flag is toggled. That way, we can lazy load the aggregates right before they are accessed via the accessor methods. I believe this will set us up for increasing performance by utilizing goroutines eventually.