### PR TITLE
4 implement accessor methods to get details about the metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,9 +31,15 @@ func main() {
 		oms.AddVersionMetric(healthcheck.Version, healthcheck.SlimMetric)
 	}
 
+	fmt.Println("\nDeliverable 1: Aggregates By Version")
+	fmt.Println("*************************************************")
 	for _, version := range oms.GetVersions() {
 		fmt.Println(version)
 	}
+
+	fmt.Println("\nDeliverable 2: Release Overview")
+	fmt.Println("------------------------------------------------------")
+	fmt.Println(oms)
 }
 
 func getFileBytes(fileName string) (*[]byte, error) {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	fmt.Println("\nDeliverable 1: Aggregates By Version")
-	fmt.Println("*************************************************")
+	fmt.Println("-------------------------------------------------")
 	for _, version := range oms.GetVersions() {
 		fmt.Println(version)
 	}

--- a/main.go
+++ b/main.go
@@ -31,6 +31,9 @@ func main() {
 		oms.AddVersionMetric(healthcheck.Version, healthcheck.SlimMetric)
 	}
 
+	for _, version := range oms.GetVersions() {
+		fmt.Println(version)
+	}
 }
 
 func getFileBytes(fileName string) (*[]byte, error) {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	var healthchecks []Healthchecks
 	if err = json.Unmarshal(*fileBytes, &healthchecks); err != nil {
 		fmt.Printf("FAILED TO PARSE JSON: %v", err)
+		return
 	}
 
 	oms := NewSlimApp()

--- a/slimapm.go
+++ b/slimapm.go
@@ -25,10 +25,10 @@ func (version *SlimVersion) IncludeMetrics(metrics SlimMetric) {
 	version.shouldAggregate = true
 }
 
-// Allows for outputing the details (deliverable 4.)
+// String for outputing the details (deliverable 4.)
 func (version SlimVersion) String() string {
 	version.aggregate()
-	return fmt.Sprintf("VERSION: %s\n  max: %d\n  min: %d\n  avg: %f", version.hash, version.max, version.min, version.avg)
+	return fmt.Sprintf("VERSION: %s\n  max: %d\n  min: %d\n  avg: %.2f", version.hash, version.max, version.min, version.avg)
 }
 
 // aggregate is called within any accessor to compute aggregate values
@@ -106,6 +106,7 @@ func (app *SlimApp) aggregate() {
 	app.shouldAggregate = false
 }
 
+// String returns the high level overview about the best and worst release
 func (app SlimApp) String() string {
 	app.aggregate()
 	return fmt.Sprintf("Best Release: %v\nWorst Release: %v", app.best.hash, app.worst.hash)

--- a/slimapm.go
+++ b/slimapm.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 type SlimMetric struct {
 	Timestamp uint32 `json:"timestamp"`
 	QueryTime uint16 `json:"query_time"`
@@ -20,10 +22,14 @@ type SlimVersion struct {
 func (version *SlimVersion) IncludeMetrics(metrics SlimMetric) {
 	version.timestamps = append(version.timestamps, metrics.Timestamp)
 	version.queryTime = append(version.queryTime, metrics.QueryTime)
+	version.shouldAggregate = true
 }
 
 // Allows for outputing the details (deliverable 4.)
-// func (version *SlimVersion) String() string
+func (version SlimVersion) String() string {
+	version.aggregate()
+	return fmt.Sprintf("VERSION: %s\nmax: %d\nmin: %d\navg: %f", version.hash, version.max, version.min, version.avg)
+}
 
 // aggregate is called within any accessor to compute aggregate values
 func (version *SlimVersion) aggregate() {
@@ -70,7 +76,15 @@ func (app *SlimApp) AddVersionMetric(version string, metric SlimMetric) error {
 }
 
 // GetVersions returns a slice of SlimVersions (deliverable 1.)
-// func (app *SlimApp) GetVersions() []SlimVersion
+func (app *SlimApp) GetVersions() []SlimVersion {
+	app.aggregate()
+	cap := len(app.versions)
+	versions := make([]SlimVersion, 0, cap)
+	for _, version := range app.versions {
+		versions = append(versions, *version)
+	}
+	return versions
+}
 
 // GetReleaseHistory returns a Pointer to a map of Times pointing to SlimVersions (deliverable 3.)
 // func (app *SlimApp) GetReleaseHistory() map[uint32]SlimVersion

--- a/slimapm.go
+++ b/slimapm.go
@@ -81,11 +81,13 @@ func (app *SlimApp) aggregate() {
 		return
 	}
 	for _, version := range app.versions {
-		if version.avg == 0.0 || version.avg < app.best.avg {
+		version.aggregate()
+		if app.best == nil || version.avg < app.best.avg {
 			app.best = version
 		}
-		if version.avg == 0.0 || version.avg > app.worst.avg {
+		if app.worst == nil || version.avg > app.worst.avg {
 			app.worst = version
 		}
 	}
+	app.shouldAggregate = false
 }

--- a/slimapm.go
+++ b/slimapm.go
@@ -28,7 +28,7 @@ func (version *SlimVersion) IncludeMetrics(metrics SlimMetric) {
 // Allows for outputing the details (deliverable 4.)
 func (version SlimVersion) String() string {
 	version.aggregate()
-	return fmt.Sprintf("VERSION: %s\nmax: %d\nmin: %d\navg: %f", version.hash, version.max, version.min, version.avg)
+	return fmt.Sprintf("VERSION: %s\n  max: %d\n  min: %d\n  avg: %f", version.hash, version.max, version.min, version.avg)
 }
 
 // aggregate is called within any accessor to compute aggregate values
@@ -104,4 +104,9 @@ func (app *SlimApp) aggregate() {
 		}
 	}
 	app.shouldAggregate = false
+}
+
+func (app SlimApp) String() string {
+	app.aggregate()
+	return fmt.Sprintf("Best Release: %v\nWorst Release: %v", app.best.hash, app.worst.hash)
 }

--- a/slimapm_test.go
+++ b/slimapm_test.go
@@ -50,3 +50,46 @@ func TestAddVersionMetric(t *testing.T) {
 		assert.Equal(t, 2, len(app.versions[version].queryTime))
 	})
 }
+
+func TestAggregateSlimVersion(t *testing.T) {
+	var slimVersionScenarios = []struct {
+		testCase        string
+		shouldAggregate bool
+		queryTime       []uint16
+		expectedMin     uint16
+		expectedMax     uint16
+		expectedAvg     float32
+	}{
+		{
+			testCase:        "should not aggregate if flag set",
+			shouldAggregate: false,
+			queryTime:       []uint16{1, 2, 3},
+			expectedMin:     0,
+			expectedMax:     0,
+			expectedAvg:     0.0,
+		},
+		{
+			testCase:        "should aggregate if flag set",
+			shouldAggregate: true,
+			queryTime:       []uint16{1, 2, 3},
+			expectedMin:     1,
+			expectedMax:     3,
+			expectedAvg:     2.0,
+		},
+	}
+
+	for _, testCase := range slimVersionScenarios {
+		version := &SlimVersion{
+			shouldAggregate: testCase.shouldAggregate,
+			queryTime:       testCase.queryTime,
+		}
+		t.Run(testCase.testCase, func(t *testing.T) {
+			version.aggregate()
+			assert.Equal(t, testCase.expectedMin, version.min)
+			assert.Equal(t, testCase.expectedMax, version.max)
+			assert.Equal(t, testCase.expectedAvg, version.avg)
+			// After running aggregate(), the flag should be set to false
+			assert.False(t, version.shouldAggregate)
+		})
+	}
+}

--- a/slimapm_test.go
+++ b/slimapm_test.go
@@ -218,3 +218,27 @@ func TestIncludeMetrics(t *testing.T) {
 		assert.True(t, version.shouldAggregate)
 	})
 }
+
+func TestStringSlimApp(t *testing.T) {
+	t.Run("should return the best and worst releases", func(t *testing.T) {
+		app := NewSlimApp()
+		app.best = &SlimVersion{shouldAggregate: false, hash: "thebest"}
+		app.worst = &SlimVersion{shouldAggregate: false, hash: "theworst"}
+		actual := app.String()
+		assert.Equal(t, "Best Release: thebest\nWorst Release: theworst", actual)
+	})
+}
+
+func TestStringSlimVersion(t *testing.T) {
+	t.Run("should return the best and worst releases", func(t *testing.T) {
+		version := &SlimVersion{
+			shouldAggregate: false,
+			hash:            "hash",
+			avg:             3.0,
+			min:             1,
+			max:             5,
+		}
+		actual := version.String()
+		assert.Equal(t, "VERSION: hash\n  max: 5\n  min: 1\n  avg: 3.00", actual)
+	})
+}


### PR DESCRIPTION
This PR includes accessor methods, with associated tests for both the `SlimApp` and the `SlimVersion`. Both implement the `Stringer` interface implementing the `String()` method. Both of these also implement an unexported helper method `aggregate()` which runs before any data about the structs is returned, if the state has changed. Thus, any time a value is add, the `shouldAggregate` flag should be toggled to `true`. The main app is also printing out the first couple of deliverables. 

I'll create a follow up task to handle the `GetVersions()` functionality.