### PR TITLE
Include get release history functionality.

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 type Healthchecks struct {
@@ -40,6 +41,12 @@ func main() {
 	fmt.Println("\nDeliverable 2: Release Overview")
 	fmt.Println("------------------------------------------------------")
 	fmt.Println(oms)
+
+	fmt.Println("\nDeliverable 3: Release History")
+	fmt.Println("------------------------------------------------------")
+	for _, version := range *oms.GetReleaseHistory() {
+		fmt.Printf("%v => %v\n", time.Unix(int64(version.start), 0), version.hash)
+	}
 }
 
 func getFileBytes(fileName string) (*[]byte, error) {

--- a/slimapm_test.go
+++ b/slimapm_test.go
@@ -242,3 +242,28 @@ func TestStringSlimVersion(t *testing.T) {
 		assert.Equal(t, "VERSION: hash\n  max: 5\n  min: 1\n  avg: 3.00", actual)
 	})
 }
+
+func TestGetReleaseHistory(t *testing.T) {
+	t.Run("should return a map organized by initial version date", func(t *testing.T) {
+		app := NewSlimApp()
+		app.AddVersionMetric("abc", SlimMetric{Timestamp: 1})
+		app.AddVersionMetric("ghi", SlimMetric{Timestamp: 5})
+		app.AddVersionMetric("def", SlimMetric{Timestamp: 2})
+		app.AddVersionMetric("def", SlimMetric{Timestamp: 3})
+		app.AddVersionMetric("def", SlimMetric{Timestamp: 4})
+		releaseHistory := app.GetReleaseHistory()
+		assert.Equal(t, struct {
+			hash  string
+			start uint32
+		}{hash: "abc", start: 1}, (*releaseHistory)[0])
+		assert.Equal(t, struct {
+			hash  string
+			start uint32
+		}{hash: "def", start: 2}, (*releaseHistory)[1])
+		assert.Equal(t, struct {
+			hash  string
+			start uint32
+		}{hash: "ghi", start: 5}, (*releaseHistory)[2])
+		assert.Equal(t, 3, len(*releaseHistory))
+	})
+}


### PR DESCRIPTION
Add a functionality to get release history. I _thought_ that `map`s were ordered by key in later versions of `golang`, but I continued to get inconsistent results so I ended up swapping to using an array of `struct`s. This can definitely be improved. I'd prefer not to pass around type-less `struct`s, but I ended in interest of time, I figured this should suffice.